### PR TITLE
Fix 'save instance state' functionality

### DIFF
--- a/buildSrc/src/main/resources/versions.properties
+++ b/buildSrc/src/main/resources/versions.properties
@@ -1,6 +1,6 @@
 # -SNAPSHOT will automatically be appended. Pass -PisRelease=true to gradlew to release.
 releaseVersion=0.4.0
 
-androidGradlePluginVersion=4.1.0-alpha06
+androidGradlePluginVersion=4.1.0-alpha08
 kotlinVersion=1.3.71
 dokkaVersion=0.10.0

--- a/compose-backstack/src/test/java/com/zachklipp/compose/backstack/SavedStateHolderTest.kt
+++ b/compose-backstack/src/test/java/com/zachklipp/compose/backstack/SavedStateHolderTest.kt
@@ -1,5 +1,6 @@
 package com.zachklipp.compose.backstack
 
+import androidx.ui.savedinstancestate.UiSavedStateRegistry
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
@@ -7,50 +8,114 @@ class SavedStateHolderTest {
 
     @Test
     fun `saves and restores`() {
-        val holder = SavedStateHolder(canBeSaved = { true }, values = mutableMapOf())
+        val parent = UiSavedStateRegistry(restoredValues = null, canBeSaved = { true })
+        val holder = SavedStateHolder("pk")
 
-        holder.setScreenVisibility(true)
-        holder.registry.registerProvider("key") { "value" }
-        holder.setScreenVisibility(false)
-        holder.registry.unregisterProvider("key")
-        holder.setScreenVisibility(true)
+        var registry = holder.updateAndReturnRegistry(parent, isVisible = true)
+        registry.registerProvider("ck") { "value" }
+        registry = holder.updateAndReturnRegistry(parent, isVisible = false)
+        registry.unregisterProvider("ck")
+        registry = holder.updateAndReturnRegistry(parent = parent, isVisible = true)
 
-        assertThat(holder.registry.consumeRestored("key")).isEqualTo("value")
+        assertThat(registry.consumeRestored("ck")).isEqualTo("value")
     }
 
     @Test
     fun `restores from initial values`() {
-        val holder =
-            SavedStateHolder(canBeSaved = { true }, values = mutableMapOf("key" to "value"))
+        val restoredValues = mutableMapOf("pk" to mapOf("ck" to "value"))
+        val parent = UiSavedStateRegistry(restoredValues = restoredValues, canBeSaved = { true })
+        val holder = SavedStateHolder("pk")
 
-        holder.setScreenVisibility(true)
+        val registry = holder.updateAndReturnRegistry(parent = parent, isVisible = true)
 
-        assertThat(holder.registry.consumeRestored("key")).isEqualTo("value")
+        assertThat(registry.consumeRestored("ck")).isEqualTo("value")
     }
 
     @Test
     fun `doesn't save unregistered providers`() {
-        val holder = SavedStateHolder(canBeSaved = { true }, values = mutableMapOf())
+        val parent = UiSavedStateRegistry(restoredValues = null, canBeSaved = { true })
+        val holder = SavedStateHolder("pk")
 
-        holder.setScreenVisibility(true)
-        holder.registry.registerProvider("key") { "value" }
-        holder.registry.unregisterProvider("key")
-        holder.setScreenVisibility(false)
-        holder.setScreenVisibility(true)
+        var registry = holder.updateAndReturnRegistry(parent, isVisible = true)
+        registry.registerProvider("key") { "value" }
+        registry.unregisterProvider("key")
+        holder.updateAndReturnRegistry(parent, isVisible = false)
+        registry = holder.updateAndReturnRegistry(parent, isVisible = true)
 
-        assertThat(holder.registry.consumeRestored("key")).isNull()
+        assertThat(registry.consumeRestored("key")).isNull()
     }
 
     @Test
     fun `preserves unrestored values from previous save`() {
-        val holder =
-            SavedStateHolder(canBeSaved = { true }, values = mutableMapOf("old key" to "old value"))
+        val restoredValues = mutableMapOf("pk" to mapOf("old key" to "old value"))
+        val parent = UiSavedStateRegistry(restoredValues = restoredValues, canBeSaved = { true })
+        val holder = SavedStateHolder("pk")
 
-        holder.setScreenVisibility(true)
+        holder.updateAndReturnRegistry(parent, isVisible = true)
         // Performs the save without having consumed "old key".
-        holder.setScreenVisibility(false)
-        holder.setScreenVisibility(true)
+        holder.updateAndReturnRegistry(parent, isVisible = false)
+        val registry = holder.updateAndReturnRegistry(parent, isVisible = true)
 
-        assertThat(holder.registry.consumeRestored("old key")).isEqualTo("old value")
+        assertThat(registry.consumeRestored("old key")).isEqualTo("old value")
+    }
+
+    @Test
+    fun `cleans up restored values from previous save`() {
+        val restoredValues = mutableMapOf("pk" to mapOf("old key" to "old value"))
+        val parent = UiSavedStateRegistry(restoredValues = restoredValues, canBeSaved = { true })
+        val holder = SavedStateHolder("pk")
+
+        var registry = holder.updateAndReturnRegistry(parent, isVisible = true)
+        val oldValue = registry.consumeRestored("old key")
+        holder.updateAndReturnRegistry(parent, isVisible = false)
+        registry = holder.updateAndReturnRegistry(parent, isVisible = true)
+
+        assertThat(oldValue).isEqualTo("old value")
+        assertThat(registry.consumeRestored("old key")).isNull()
+    }
+
+    @Test
+    fun `parent saves contain values from the currently visible screen`() {
+        val parent = UiSavedStateRegistry(restoredValues = null, canBeSaved = { true })
+        val holder = SavedStateHolder("pk")
+
+        val registry = holder.updateAndReturnRegistry(parent, isVisible = true)
+        registry.registerProvider("ck") { "value" }
+
+        val values = parent.performSave()
+        assertThat(values["pk"]).isEqualTo(mapOf("ck" to "value"))
+    }
+
+    @Test
+    fun `parent saves contain values from non-visible screens`() {
+        val parent = UiSavedStateRegistry(restoredValues = null, canBeSaved = { true })
+        val holder = SavedStateHolder("pk")
+
+        var registry = holder.updateAndReturnRegistry(parent, isVisible = true)
+        registry.registerProvider("ck") { "value" }
+        registry = holder.updateAndReturnRegistry(parent, isVisible = false)
+        registry.unregisterProvider("ck")
+
+        val values = parent.performSave()
+        assertThat(values["pk"]).isEqualTo(mapOf("ck" to "value"))
+    }
+
+    @Test
+    fun `parent saves contain values from nested children`() {
+        val topStateHolder = SavedStateHolder("pk1")
+        val middleStateHolder = SavedStateHolder("pk2")
+
+        val topRegistry = UiSavedStateRegistry(restoredValues = null, canBeSaved = { true })
+        val middleRegistry = topStateHolder.updateAndReturnRegistry(topRegistry, isVisible = true)
+        val bottomRegistry = middleStateHolder.updateAndReturnRegistry(middleRegistry, isVisible = true)
+
+        middleRegistry.registerProvider("ck1") { "middle value" }
+        bottomRegistry.registerProvider("ck2") { "bottom value" }
+
+        val values = topRegistry.performSave()
+        assertThat(values["pk1"]).isEqualTo(mapOf(
+            "ck1" to "middle value",
+            "pk2" to mapOf("ck2" to "bottom value")
+        ))
     }
 }


### PR DESCRIPTION
Fixes #28 

Most of this functionality is borrowed directly from how `rememberSavedInstanceState` works. Each screen now registers its own provider with its parent `UiSavedStateRegistry`. This means when compose-provided (topmost) registry saves, all of our child registries recursively save too. The rest of the implementation is identical, we still trigger save when a screen transitions offscreen, and restore that state when a screen comes back onscreen. 

Happy to make any changes/improvements! 