### PR TITLE
Fix TransitionController to no longer perform side effects directly in composition.

### DIFF
--- a/compose-backstack/src/main/java/com/zachklipp/compose/backstack/FrameController.kt
+++ b/compose-backstack/src/main/java/com/zachklipp/compose/backstack/FrameController.kt
@@ -1,10 +1,13 @@
 package com.zachklipp.compose.backstack
 
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import com.zachklipp.compose.backstack.FrameController.BackstackFrame
 
@@ -25,17 +28,23 @@ interface FrameController<T : Any> {
    * The frames that are currently being active. All active frames will be composed. When a frame
    * that is in the backstack stops appearing in this list, its state will be saved.
    *
-   * Should be backed by either a `MutableState<List<T>>` or a `MutableStateList<T>`. This property
+   * Should be backed by either a [MutableState] or a [SnapshotStateList]. This property
    * will not be read until after [updateBackstack] is called at least once.
    */
   val activeFrames: List<BackstackFrame<T>>
 
   /**
-   * Notifies the controller that a new backstack was passed in. This should probably result in the
+   * Notifies the controller that a new backstack was passed in. This method must initialize
+   * [activeFrames] first time it's called, and subsequently should probably result in
    * [activeFrames] being updated to show new keys or hide old ones, although the controller may
    * choose to do that later (e.g. if one of the active frames is currently being animated).
    *
-   * [keys] will always contain at least one element.
+   * This method will be called _directly from the composition_ – it must not perform side effects
+   * or update any state that is not backed by snapshot state objects (such as [MutableState]s,
+   * lists created by [mutableStateListOf], etc.).
+   *
+   * @param keys The latest backstack passed to [Backstack]. Will always contain at least one
+   * element.
    */
   fun updateBackstack(keys: List<T>)
 

--- a/compose-backstack/src/main/java/com/zachklipp/compose/backstack/TransitionController.kt
+++ b/compose-backstack/src/main/java/com/zachklipp/compose/backstack/TransitionController.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.TweenSpec
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -14,6 +15,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.platform.LocalContext
@@ -22,7 +24,7 @@ import com.zachklipp.compose.backstack.TransitionDirection.Backward
 import com.zachklipp.compose.backstack.TransitionDirection.Forward
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.collect
 
 /**
  * Returns the default [AnimationSpec] used for [rememberTransitionController].
@@ -55,6 +57,10 @@ import kotlinx.coroutines.launch
     it.animationSpec = animationSpec
     it.onTransitionStarting = onTransitionStarting
     it.onTransitionFinished = onTransitionFinished
+
+    LaunchedEffect(it) {
+      it.runTransitionAnimations()
+    }
   }
 }
 
@@ -80,22 +86,23 @@ internal class TransitionController<T : Any>(
 
   // These aren't MutableStates because they're only read when a backstack change happens. They
   // don't need to trigger anything when they're changed.
-  lateinit var transition: BackstackTransition
-  lateinit var animationSpec: AnimationSpec<Float>
-  lateinit var onTransitionStarting: (from: List<T>, to: List<T>, TransitionDirection) -> Unit
-  lateinit var onTransitionFinished: () -> Unit
+  var transition: BackstackTransition? by mutableStateOf(null)
+  var animationSpec: AnimationSpec<Float>? by mutableStateOf(null)
+  var onTransitionStarting: ((from: List<T>, to: List<T>, TransitionDirection) -> Unit)?
+      by mutableStateOf(null)
+  var onTransitionFinished: (() -> Unit)? by mutableStateOf(null)
 
   /**
    * A snapshot of the backstack that will remain unchanged during transitions, even if
    * [updateBackstack] is called with a different stack. Just before
-   * [starting a transition][startTransition], this list will be used to determine if we should use
+   * [starting a transition][animateTransition], this list will be used to determine if we should use
    * a forwards or backwards animation. It's a [MutableState] because it is used to derive the value
    * for [activeFrames], and so it needs to be observable.
    */
-  private var activeKeys: List<T> by mutableStateOf(emptyList())
+  private var displayedKeys: List<T> by mutableStateOf(emptyList())
 
   /** The latest list of keys seen by [updateBackstack]. */
-  private var targetKeys = emptyList<T>()
+  private var targetKeys by mutableStateOf(emptyList<T>())
 
   /**
    * Set to a non-null value only when actively animating between screens as the result of a call
@@ -104,45 +111,60 @@ internal class TransitionController<T : Any>(
    */
   private var activeTransition: ActiveTransition<T>? by mutableStateOf(null)
 
-  override val activeFrames: List<BackstackFrame<T>>
-    get() = activeTransition?.let { transition ->
+  override val activeFrames: List<BackstackFrame<T>> by derivedStateOf {
+    activeTransition?.let { transition ->
       if (transition.popping) {
         listOf(transition.toFrame, transition.fromFrame)
       } else {
         listOf(transition.fromFrame, transition.toFrame)
       }
-    } ?: listOf(BackstackFrame(activeKeys.last()))
+    } ?: listOf(BackstackFrame(displayedKeys.last()))
+  }
+
+  /**
+   * Should be called from a coroutine that has access to a frame clock (i.e. from a
+   * [rememberCoroutineScope] or in a [LaunchedEffect]), and must be allowed to run until this
+   * [TransitionController] leaves the composition. It will never return unless cancelled.
+   */
+  suspend fun runTransitionAnimations() {
+    // This flow handles backpressure by conflating: if targetKeys is changed multiple times while
+    // an animation is running, we'll only get a single emission when it finishes.
+    snapshotFlow { targetKeys }.collect { targetKeys ->
+      if (displayedKeys.last() == targetKeys.last()) {
+        // The visible screen didn't change, so we don't need to animate, but we need to update our
+        // active list for the next time we check for navigation direction.
+        displayedKeys = targetKeys
+        return@collect
+      }
+
+      // The top of the stack was changed, so animate to the new top.
+      animateTransition(fromKeys = displayedKeys, toKeys = targetKeys)
+    }
+  }
 
   override fun updateBackstack(keys: List<T>) {
     // Always remember the latest stack, so if this call is happening during a transition we can
     // detect that when the transition finishes and start the next transition.
     targetKeys = keys
 
-    // We're in the middle of a transition, don't do anything.
-    if (activeTransition != null) return
-
-    // Either this is the first call or the visible screen didn't change but we need to update our
-    // active list for the next time we check for navigation direction.
-    if (activeKeys.isEmpty() || keys.last() == activeKeys.last()) {
-      activeKeys = keys
-      return
+    // This is the first update, so we don't animate, and need to show the backstack as-is
+    // immediately.
+    if (displayedKeys.isEmpty()) {
+      displayedKeys = keys
     }
-
-    // We're idle and the visible frame changed so we need to start animating.
-    startTransition()
   }
 
   /**
    * Called when [updateBackstack] gets a new backstack with a new top frame while idle, or after a
-   * transition if the [targetKeys]' top is not [activeKeys]' top.
+   * transition if the [targetKeys]' top is not [displayedKeys]' top.
    */
   @OptIn(ExperimentalCoroutinesApi::class)
-  private fun startTransition() {
+  private suspend fun animateTransition(fromKeys: List<T>, toKeys: List<T>) {
     check(activeTransition == null) { "Can only start transitioning while idle." }
 
-    val fromKey = activeKeys.last()
-    val toKey = targetKeys.last()
-    val popping = toKey in activeKeys
+    val fromKey = fromKeys.last()
+    val toKey = toKeys.last()
+    val popping = toKey in fromKeys
     val progress = Animatable(0f)
 
     val fromVisibility = derivedStateOf { 1f - progress.value }
@@ -151,12 +173,12 @@ internal class TransitionController<T : Any>(
     // Wrap modifier functions in each their own recompose scope so that if they read the visibility
     // (or any other state) directly, the modified node will actually be updated.
     val fromModifier = Modifier.composed {
-      with(transition) {
+      with(transition!!) {
         modifierForScreen(fromVisibility, isTop = popping)
       }
     }
     val toModifier = Modifier.composed {
-      with(transition) {
+      with(transition!!) {
         modifierForScreen(toVisibility, isTop = !popping)
       }
     }
@@ -167,19 +189,12 @@ internal class TransitionController<T : Any>(
       popping = popping
     )
 
-    val oldActiveKeys = activeKeys
-    activeKeys = targetKeys
+    val oldActiveKeys = displayedKeys
+    displayedKeys = targetKeys
 
-    scope.launch {
-      onTransitionStarting(oldActiveKeys, activeKeys, if (popping) Backward else Forward)
-      progress.animateTo(1f, animationSpec)
-      activeTransition = null
-      onTransitionFinished()
-
-      if (targetKeys.last() != activeKeys.last()) {
-        // We got a new top while we were transitioning, so do that transition now.
-        startTransition()
-      }
-    }
+    onTransitionStarting!!(oldActiveKeys, displayedKeys, if (popping) Backward else Forward)
+    progress.animateTo(1f, animationSpec!!)
+    activeTransition = null
+    onTransitionFinished!!()
   }
 }


### PR DESCRIPTION
Performing side effects in composition, without using one of the effect functions, is dangerous because if compositions may be ran on multiple threads in parallel, and if the composition does not complete successfully, the side effects may be running in an invalid state. TransitionController was updating non-`MutableState` properties directly from `updateTransition`(which is called directly from a composition) and even launching coroutines to perform transition animations. This is particularly bad because if the composition later failed, we'd be animating a transition which, as far as compose is concerned, never actually occured.

Instead, now `TransitionController.updateBackstack` simply sets `targetKeys` (which is now a `MutableState`) and ensures that `displayedKeys` (previously called `activeKeys`) is initialized on the first call. Animations are performed by a long-running `LaunchedEffect` which uses `snapshotFlow` to observe `targetKeys` changes and run the animations inline. Using a conflated `Flow` means we also don't need to explicitly synchronize to avoid overlapping transitions – the flow collector exerts backpressure while a transition is animating, and any backstack updates that occur during that time will be conflated.

This change also makes all the properties of `TransitionController` that are updated by `rememberTransitionController` `MutableState`s, because while we don't need to observe them for changes, we do need to make sure they are thread-safe and rolled back if the composition fails.