### PR TITLE
API overhaul because splitting the keys and the composables don't work.

### DIFF
--- a/buildSrc/src/main/resources/versions.properties
+++ b/buildSrc/src/main/resources/versions.properties
@@ -1,3 +1,3 @@
 # -SNAPSHOT will automatically be appended. Pass -PisRelease=true to gradlew to release (this will
 # also append the current compose version number after a +).
-releaseVersion=0.10.0
+releaseVersion=0.11.0

--- a/compose-backstack-viewer/src/main/java/com/zachklipp/compose/backstack/viewer/BackstackViewerApp.kt
+++ b/compose-backstack-viewer/src/main/java/com/zachklipp/compose/backstack/viewer/BackstackViewerApp.kt
@@ -41,6 +41,7 @@ import com.zachklipp.compose.backstack.BackstackTransition.Crossfade
 import com.zachklipp.compose.backstack.BackstackTransition.Slide
 import com.zachklipp.compose.backstack.defaultBackstackAnimation
 import com.zachklipp.compose.backstack.rememberTransitionController
+import com.zachklipp.compose.backstack.toBackstackModel
 import com.zachklipp.compose.backstack.xray.xrayed
 
 private val DEFAULT_BACKSTACKS = listOf(
@@ -147,7 +148,14 @@ private fun AppScreens(model: AppModel) {
 
   MaterialTheme(colors = lightColors()) {
     Backstack(
-      backstack = model.currentBackstack,
+      frames = model.currentBackstack.toBackstackModel { screen ->
+        AppScreen(
+          name = screen,
+          showBack = screen != model.bottomScreen,
+          onAdd = { model.pushScreen("$screen+") },
+          onBack = model::popScreen
+        )
+      },
       frameController = rememberTransitionController<String>(
         transition = model.selectedTransition.second,
         animationSpec = animation ?: defaultBackstackAnimation(),
@@ -165,14 +173,7 @@ private fun AppScreens(model: AppModel) {
       modifier = Modifier
         .fillMaxSize()
         .border(width = 3.dp, color = Color.Red),
-    ) { screen ->
-      AppScreen(
-        name = screen,
-        showBack = screen != model.bottomScreen,
-        onAdd = { model.pushScreen("$screen+") },
-        onBack = model::popScreen
-      )
-    }
+    )
   }
 }
 

--- a/compose-backstack-xray/src/main/java/com/zachklipp/compose/backstack/xray/XrayController.kt
+++ b/compose-backstack-xray/src/main/java/com/zachklipp/compose/backstack/xray/XrayController.kt
@@ -12,8 +12,9 @@ import androidx.compose.ui.graphics.DefaultCameraDistance
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
+import com.zachklipp.compose.backstack.BackstackFrame
 import com.zachklipp.compose.backstack.FrameController
-import com.zachklipp.compose.backstack.FrameController.BackstackFrame
+import com.zachklipp.compose.backstack.FrameController.FrameAndModifier
 import com.zachklipp.compose.backstack.NoopFrameController
 import kotlin.math.sin
 
@@ -22,16 +23,16 @@ import kotlin.math.sin
  * the screens in the backstack in pseudo-3D space. The 3D stack can be navigated via touch
  * gestures.
  */
-@Composable fun <T : Any> FrameController<T>.xrayed(enabled: Boolean): FrameController<T> =
-  remember { XrayController<T>() }.also {
+@Composable fun <K : Any> FrameController<K>.xrayed(enabled: Boolean): FrameController<K> =
+  remember { XrayController<K>() }.also {
     it.enabled = enabled
     it.wrappedController = this
   }
 
-private class XrayController<T : Any> : FrameController<T> {
+private class XrayController<K : Any> : FrameController<K> {
 
   var enabled: Boolean by mutableStateOf(false)
-  var wrappedController: FrameController<T> by mutableStateOf(NoopFrameController())
+  var wrappedController: FrameController<K> by mutableStateOf(NoopFrameController())
 
   private var offsetDpX by mutableStateOf(500.dp)
   private var offsetDpY by mutableStateOf(10.dp)
@@ -41,7 +42,7 @@ private class XrayController<T : Any> : FrameController<T> {
   private var alpha by mutableStateOf(.4f)
   private var overlayAlpha by mutableStateOf(.2f)
 
-  private var activeKeys by mutableStateOf(emptyList<T>())
+  private var activeKeys by mutableStateOf(emptyList<BackstackFrame<K>>())
 
   private val controlModifier = Modifier.pointerInput(Unit) {
     detectTransformGestures { _, pan, zoom, _ ->
@@ -56,14 +57,14 @@ private class XrayController<T : Any> : FrameController<T> {
     if (!enabled) wrappedController.activeFrames else {
       activeKeys.mapIndexed { index, key ->
         val modifier = Modifier.modifierForFrame(index, activeKeys.size, 1f)
-        return@mapIndexed BackstackFrame(key, modifier)
+        return@mapIndexed FrameAndModifier(key, modifier)
       }
     }
   }
 
-  override fun updateBackstack(keys: List<T>) {
-    activeKeys = keys
-    wrappedController.updateBackstack(keys)
+  override fun updateBackstack(frames: List<BackstackFrame<K>>) {
+    activeKeys = frames
+    wrappedController.updateBackstack(frames)
   }
 
   /**

--- a/compose-backstack/api/compose-backstack.api
+++ b/compose-backstack/api/compose-backstack.api
@@ -1,8 +1,11 @@
+public abstract interface class com/zachklipp/compose/backstack/BackstackFrame {
+	public abstract fun Content (Landroidx/compose/runtime/Composer;I)V
+	public abstract fun getKey ()Ljava/lang/Object;
+}
+
 public final class com/zachklipp/compose/backstack/BackstackKt {
-	public static final fun Backstack (Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/zachklipp/compose/backstack/BackstackTransition;Landroidx/compose/animation/core/AnimationSpec;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)V
-	public static final fun Backstack (Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/zachklipp/compose/backstack/BackstackTransition;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
-	public static final fun Backstack (Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/zachklipp/compose/backstack/FrameController;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
-	public static synthetic fun Backstack$default (Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/zachklipp/compose/backstack/BackstackTransition;Landroidx/compose/animation/core/AnimationSpec;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public static final fun Backstack (Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/zachklipp/compose/backstack/BackstackTransition;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Backstack (Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/zachklipp/compose/backstack/FrameController;Landroidx/compose/runtime/Composer;II)V
 }
 
 public abstract interface class com/zachklipp/compose/backstack/BackstackTransition {
@@ -30,15 +33,15 @@ public abstract interface class com/zachklipp/compose/backstack/FrameController 
 	public abstract fun updateBackstack (Ljava/util/List;)V
 }
 
-public final class com/zachklipp/compose/backstack/FrameController$BackstackFrame {
-	public fun <init> (Ljava/lang/Object;Landroidx/compose/ui/Modifier;)V
-	public synthetic fun <init> (Ljava/lang/Object;Landroidx/compose/ui/Modifier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Object;
+public final class com/zachklipp/compose/backstack/FrameController$FrameAndModifier {
+	public fun <init> (Lcom/zachklipp/compose/backstack/BackstackFrame;Landroidx/compose/ui/Modifier;)V
+	public synthetic fun <init> (Lcom/zachklipp/compose/backstack/BackstackFrame;Landroidx/compose/ui/Modifier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/zachklipp/compose/backstack/BackstackFrame;
 	public final fun component2 ()Landroidx/compose/ui/Modifier;
-	public final fun copy (Ljava/lang/Object;Landroidx/compose/ui/Modifier;)Lcom/zachklipp/compose/backstack/FrameController$BackstackFrame;
-	public static synthetic fun copy$default (Lcom/zachklipp/compose/backstack/FrameController$BackstackFrame;Ljava/lang/Object;Landroidx/compose/ui/Modifier;ILjava/lang/Object;)Lcom/zachklipp/compose/backstack/FrameController$BackstackFrame;
+	public final fun copy (Lcom/zachklipp/compose/backstack/BackstackFrame;Landroidx/compose/ui/Modifier;)Lcom/zachklipp/compose/backstack/FrameController$FrameAndModifier;
+	public static synthetic fun copy$default (Lcom/zachklipp/compose/backstack/FrameController$FrameAndModifier;Lcom/zachklipp/compose/backstack/BackstackFrame;Landroidx/compose/ui/Modifier;ILjava/lang/Object;)Lcom/zachklipp/compose/backstack/FrameController$FrameAndModifier;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getKey ()Ljava/lang/Object;
+	public final fun getFrame ()Lcom/zachklipp/compose/backstack/BackstackFrame;
 	public final fun getModifier ()Landroidx/compose/ui/Modifier;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/compose-backstack/src/androidTest/java/com/zachklipp/compose/backstack/BackstackTransitionsTest.kt
+++ b/compose-backstack/src/androidTest/java/com/zachklipp/compose/backstack/BackstackTransitionsTest.kt
@@ -63,10 +63,12 @@ class BackstackTransitionsTest {
     assertTransition(Crossfade, forward = false)
   }
 
+  private fun List<String>.toBackstack() = toBackstackModel { BasicText(it) }
+
   private fun assertInitialStateWithSingleScreen(transition: BackstackTransition) {
     val originalBackstack = listOf("one")
     compose.setContent {
-      Backstack(originalBackstack, transition = transition) { BasicText(it) }
+      Backstack(originalBackstack.toBackstack(), transition = transition)
     }
 
     compose.onNodeWithText("one").assertIsDisplayed()
@@ -75,7 +77,7 @@ class BackstackTransitionsTest {
   private fun assertInitialStateWithMultipleScreens(transition: BackstackTransition) {
     val originalBackstack = listOf("one", "two")
     compose.setContent {
-      Backstack(originalBackstack, transition = transition) { BasicText(it) }
+      Backstack(originalBackstack.toBackstack(), transition = transition)
     }
 
     compose.onNodeWithText("two").assertIsDisplayed()
@@ -87,15 +89,17 @@ class BackstackTransitionsTest {
     val secondBackstack = listOf("one", "two")
     var backstack by mutableStateOf(if (forward) firstBackstack else secondBackstack)
     compose.mainClock.autoAdvance = false
+
     compose.setContent {
       Backstack(
-        backstack,
+        backstack.toBackstack(),
         frameController = rememberTransitionController(
           animationSpec = animation,
           transition = transition
         )
-      ) { BasicText(it) }
+      )
     }
+
     val initialText = if (forward) "one" else "two"
     val newText = if (forward) "two" else "one"
 

--- a/compose-backstack/src/main/java/com/zachklipp/compose/backstack/BackstackFrame.kt
+++ b/compose-backstack/src/main/java/com/zachklipp/compose/backstack/BackstackFrame.kt
@@ -1,0 +1,44 @@
+package com.zachklipp.compose.backstack
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Models a frame in a Backstack, with a unique [key] to identify it,
+ * and a [Content] function to display it.
+ *
+ * Use [toBackstackModel] to associate any [List] of UI models with
+ * with [Composable] code that can display them, suitable for use
+ * with [Backstack].
+ */
+interface BackstackFrame<out K : Any> {
+  val key: K
+  @Composable fun Content()
+}
+
+inline fun <reified M : Any, K : Any> BackstackFrame(
+  model: M,
+  key: K,
+  crossinline content: @Composable (M) -> Unit
+): BackstackFrame<K> = object : BackstackFrame<K> {
+  override val key = key
+
+  @Composable override fun Content() {
+    content(model)
+  }
+}
+
+inline fun <reified M: Any> List<M>.toBackstackModel(
+  crossinline content: @Composable (M) -> Unit
+): List<BackstackFrame<M>>{
+  return toBackstackModel(
+    getKey =  { it },
+    content = content
+  )
+}
+
+inline fun <reified M : Any, K : Any> List<M>.toBackstackModel(
+  getKey: (M) -> K,
+  crossinline content: @Composable (M) -> Unit
+): List<BackstackFrame<K>> {
+  return map { BackstackFrame(it, getKey(it), content) }
+}

--- a/compose-backstack/src/main/java/com/zachklipp/compose/backstack/FrameController.kt
+++ b/compose-backstack/src/main/java/com/zachklipp/compose/backstack/FrameController.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
-import com.zachklipp.compose.backstack.FrameController.BackstackFrame
+import com.zachklipp.compose.backstack.FrameController.FrameAndModifier
 
 /**
  * A stable object that processes changes to a [Backstack]'s list of screen keys, determining which
@@ -22,7 +22,7 @@ import com.zachklipp.compose.backstack.FrameController.BackstackFrame
  * for a while, even after they're removed from the backstack, in order to animate their removal.
  */
 @Stable
-interface FrameController<T : Any> {
+interface FrameController<K : Any> {
 
   /**
    * The frames that are currently being active. All active frames will be composed. When a frame
@@ -31,7 +31,7 @@ interface FrameController<T : Any> {
    * Should be backed by either a [MutableState] or a [SnapshotStateList]. This property
    * will not be read until after [updateBackstack] is called at least once.
    */
-  val activeFrames: List<BackstackFrame<T>>
+  val activeFrames: List<FrameAndModifier<K>>
 
   /**
    * Notifies the controller that a new backstack was passed in. This method must initialize
@@ -43,17 +43,17 @@ interface FrameController<T : Any> {
    * or update any state that is not backed by snapshot state objects (such as [MutableState]s,
    * lists created by [mutableStateListOf], etc.).
    *
-   * @param keys The latest backstack passed to [Backstack]. Will always contain at least one
+   * @param frames The latest backstack passed to [Backstack]. Will always contain at least one
    * element.
    */
-  fun updateBackstack(keys: List<T>)
+  fun updateBackstack(frames: List<BackstackFrame<K>>)
 
   /**
    * A frame controlled by a [FrameController], to be shown by [Backstack].
    */
   @Immutable
-  data class BackstackFrame<out T : Any>(
-    val key: T,
+  data class FrameAndModifier<out K : Any>(
+    val frame: BackstackFrame<K>,
     val modifier: Modifier = Modifier
   )
 }
@@ -62,15 +62,15 @@ interface FrameController<T : Any> {
  * Returns a [FrameController] that always just shows the top frame without any special effects.
  */
 @Suppress("UNCHECKED_CAST")
-fun <T : Any> NoopFrameController(): FrameController<T> = NoopFrameController as FrameController<T>
+fun <K : Any> NoopFrameController(): FrameController<K> = NoopFrameController as FrameController<K>
 
 private object NoopFrameController : FrameController<Any> {
-  private var topFrame by mutableStateOf<BackstackFrame<Any>?>(null)
+  private var topFrame by mutableStateOf<FrameAndModifier<Any>?>(null)
 
-  override val activeFrames: List<BackstackFrame<Any>>
+  override val activeFrames: List<FrameAndModifier<Any>>
     get() = topFrame?.let { listOf(it) } ?: emptyList()
 
-  override fun updateBackstack(keys: List<Any>) {
-    topFrame = BackstackFrame(keys.last())
+  override fun updateBackstack(frames: List<BackstackFrame<Any>>) {
+    topFrame = FrameAndModifier(frames.last())
   }
 }

--- a/compose-backstack/src/main/java/com/zachklipp/compose/backstack/TransitionController.kt
+++ b/compose-backstack/src/main/java/com/zachklipp/compose/backstack/TransitionController.kt
@@ -1,5 +1,6 @@
 package com.zachklipp.compose.backstack
 
+import android.annotation.SuppressLint
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.compose.animation.core.Animatable
@@ -19,12 +20,14 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.platform.LocalContext
-import com.zachklipp.compose.backstack.FrameController.BackstackFrame
+import com.zachklipp.compose.backstack.FrameController.FrameAndModifier
 import com.zachklipp.compose.backstack.TransitionDirection.Backward
 import com.zachklipp.compose.backstack.TransitionDirection.Forward
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
+
+typealias OnTransitionStarting<K> =
+    (from: List<BackstackFrame<K>>, to: List<BackstackFrame<K>>, TransitionDirection) -> Unit
 
 /**
  * Returns the default [AnimationSpec] used for [rememberTransitionController].
@@ -45,14 +48,14 @@ import kotlinx.coroutines.flow.collect
  * @param onTransitionStarting Callback that will be invoked before starting each transition.
  * @param onTransitionFinished Callback that will be invoked after each transition finishes.
  */
-@Composable fun <T : Any> rememberTransitionController(
+@Composable fun <K : Any> rememberTransitionController(
   transition: BackstackTransition = BackstackTransition.Slide,
   animationSpec: AnimationSpec<Float> = defaultBackstackAnimation(),
-  onTransitionStarting: (from: List<T>, to: List<T>, TransitionDirection) -> Unit = { _, _, _ -> },
+  onTransitionStarting: OnTransitionStarting<K> = { _, _, _ -> },
   onTransitionFinished: () -> Unit = {},
-): FrameController<T> {
+): FrameController<K> {
   val scope = rememberCoroutineScope()
-  return remember { TransitionController<T>(scope) }.also {
+  return remember { TransitionController<K>(scope) }.also {
     it.transition = transition
     it.animationSpec = animationSpec
     it.onTransitionStarting = onTransitionStarting
@@ -70,24 +73,23 @@ import kotlinx.coroutines.flow.collect
  * @param scope The [CoroutineScope] used for animations.
  */
 @VisibleForTesting(otherwise = PRIVATE)
-internal class TransitionController<T : Any>(
+internal class TransitionController<K : Any>(
   private val scope: CoroutineScope
-) : FrameController<T> {
+) : FrameController<K> {
 
   /**
    * Holds information about an in-progress transition.
    */
   @Immutable
-  private data class ActiveTransition<T : Any>(
-    val fromFrame: BackstackFrame<T>,
-    val toFrame: BackstackFrame<T>,
+  private data class ActiveTransition<K : Any>(
+    val fromFrame: FrameAndModifier<K>,
+    val toFrame: FrameAndModifier<K>,
     val popping: Boolean
   )
 
   var transition: BackstackTransition? by mutableStateOf(null)
   var animationSpec: AnimationSpec<Float>? by mutableStateOf(null)
-  var onTransitionStarting: ((from: List<T>, to: List<T>, TransitionDirection) -> Unit)?
-      by mutableStateOf(null)
+  var onTransitionStarting: OnTransitionStarting<K>? by mutableStateOf(null)
   var onTransitionFinished: (() -> Unit)? by mutableStateOf(null)
 
   /**
@@ -97,26 +99,26 @@ internal class TransitionController<T : Any>(
    * a forwards or backwards animation. It's a [MutableState] because it is used to derive the value
    * for [activeFrames], and so it needs to be observable.
    */
-  private var displayedKeys: List<T> by mutableStateOf(emptyList())
+  private var displayedFrames: List<BackstackFrame<K>> by mutableStateOf(emptyList())
 
   /** The latest list of keys seen by [updateBackstack]. */
-  private var targetKeys by mutableStateOf(emptyList<T>())
+  private var targetFrames by mutableStateOf(emptyList<BackstackFrame<K>>())
 
   /**
    * Set to a non-null value only when actively animating between screens as the result of a call
    * to [updateBackstack]. This is a [MutableState] because it's used to derive the value of
    * [activeFrames], and so it needs to be observable.
    */
-  private var activeTransition: ActiveTransition<T>? by mutableStateOf(null)
+  private var activeTransition: ActiveTransition<K>? by mutableStateOf(null)
 
-  override val activeFrames: List<BackstackFrame<T>> by derivedStateOf {
+  override val activeFrames: List<FrameAndModifier<K>> by derivedStateOf {
     activeTransition?.let { transition ->
       if (transition.popping) {
         listOf(transition.toFrame, transition.fromFrame)
       } else {
         listOf(transition.fromFrame, transition.toFrame)
       }
-    } ?: listOf(BackstackFrame(displayedKeys.last()))
+    } ?: listOf(FrameAndModifier(displayedFrames.last()))
   }
 
   /**
@@ -127,42 +129,43 @@ internal class TransitionController<T : Any>(
   suspend fun runTransitionAnimations() {
     // This flow handles backpressure by conflating: if targetKeys is changed multiple times while
     // an animation is running, we'll only get a single emission when it finishes.
-    snapshotFlow { targetKeys }.collect { targetKeys ->
-      if (displayedKeys.last() == targetKeys.last()) {
+    snapshotFlow { targetFrames }.collect { targetFrames ->
+      if (displayedFrames.last().key == targetFrames.last().key) {
         // The visible screen didn't change, so we don't need to animate, but we need to update our
         // active list for the next time we check for navigation direction.
-        displayedKeys = targetKeys
+        displayedFrames = targetFrames
         return@collect
       }
 
       // The top of the stack was changed, so animate to the new top.
-      animateTransition(fromKeys = displayedKeys, toKeys = targetKeys)
+      animateTransition(fromFrames = displayedFrames, toFrames = targetFrames)
     }
   }
 
-  override fun updateBackstack(keys: List<T>) {
+  override fun updateBackstack(frames: List<BackstackFrame<K>>) {
     // Always remember the latest stack, so if this call is happening during a transition we can
     // detect that when the transition finishes and start the next transition.
-    targetKeys = keys
+    targetFrames = frames
 
     // This is the first update, so we don't animate, and need to show the backstack as-is
     // immediately.
-    if (displayedKeys.isEmpty()) {
-      displayedKeys = keys
+    if (displayedFrames.isEmpty()) {
+      displayedFrames = frames
     }
   }
 
   /**
    * Called when [updateBackstack] gets a new backstack with a new top frame while idle, or after a
-   * transition if the [targetKeys]' top is not [displayedKeys]' top.
+   * transition if the [targetFrames]' top is not [displayedFrames]' top.
    */
-  @OptIn(ExperimentalCoroutinesApi::class)
-  private suspend fun animateTransition(fromKeys: List<T>, toKeys: List<T>) {
+  private suspend fun animateTransition(
+    fromFrames: List<BackstackFrame<K>>, toFrames: List<BackstackFrame<K>>
+  ) {
     check(activeTransition == null) { "Can only start transitioning while idle." }
 
-    val fromKey = fromKeys.last()
-    val toKey = toKeys.last()
-    val popping = toKey in fromKeys
+    val fromFrame = fromFrames.last()
+    val toFrame = toFrames.last()
+    val popping = fromFrames.firstOrNull { it.key == toFrame.key } != null
     val progress = Animatable(0f)
 
     val fromVisibility = derivedStateOf { 1f - progress.value }
@@ -170,11 +173,14 @@ internal class TransitionController<T : Any>(
 
     // Wrap modifier functions in each their own recompose scope so that if they read the visibility
     // (or any other state) directly, the modified node will actually be updated.
+    @SuppressLint("UnnecessaryComposedModifier")
     val fromModifier = Modifier.composed {
       with(transition!!) {
         modifierForScreen(fromVisibility, isTop = popping)
       }
     }
+
+    @SuppressLint("UnnecessaryComposedModifier")
     val toModifier = Modifier.composed {
       with(transition!!) {
         modifierForScreen(toVisibility, isTop = !popping)
@@ -182,15 +188,15 @@ internal class TransitionController<T : Any>(
     }
 
     activeTransition = ActiveTransition(
-      fromFrame = BackstackFrame(fromKey, fromModifier),
-      toFrame = BackstackFrame(toKey, toModifier),
+      fromFrame = FrameAndModifier(fromFrame, fromModifier),
+      toFrame = FrameAndModifier(toFrame, toModifier),
       popping = popping
     )
 
-    val oldActiveKeys = displayedKeys
-    displayedKeys = targetKeys
+    val oldActiveFrames = displayedFrames
+    displayedFrames = targetFrames
 
-    onTransitionStarting!!(oldActiveKeys, displayedKeys, if (popping) Backward else Forward)
+    onTransitionStarting!!(oldActiveFrames, displayedFrames, if (popping) Backward else Forward)
     progress.animateTo(1f, animationSpec!!)
     activeTransition = null
     onTransitionFinished!!()

--- a/compose-backstack/src/test/java/com/zachklipp/compose/backstack/TransitionControllerTest.kt
+++ b/compose-backstack/src/test/java/com/zachklipp/compose/backstack/TransitionControllerTest.kt
@@ -3,7 +3,7 @@ package com.zachklipp.compose.backstack
 import androidx.compose.animation.core.TweenSpec
 import com.google.common.truth.Truth.assertThat
 import com.zachklipp.compose.backstack.BackstackTransition.Crossfade
-import com.zachklipp.compose.backstack.FrameController.BackstackFrame
+import com.zachklipp.compose.backstack.FrameController.FrameAndModifier
 import kotlinx.coroutines.CoroutineScope
 import org.junit.Test
 import kotlin.coroutines.EmptyCoroutineContext
@@ -22,7 +22,8 @@ class TransitionControllerTest {
   }
 
   @Test fun `initial update sets activeFrames`() {
-    controller.updateBackstack(listOf("hello"))
-    assertThat(controller.activeFrames).containsExactly(BackstackFrame("hello"))
+    val frame = BackstackFrame("hello", "hello") {}
+    controller.updateBackstack(listOf(frame))
+    assertThat(controller.activeFrames).containsExactly(FrameAndModifier(frame))
   }
 }


### PR DESCRIPTION
All of our tests and demos were built using `String` as the key, with `content` that does nothing but render the key.
This approach doesn't reflect reality very well, and masked #63, where keys for more interesting objects can get out of sync with the `content` lambda that can render them.
When popping, you would wind up crashing when the up to date lambda is unable to interpret the key for the screen that is being animated away.

The fix is to change the API from something that takes a list of keys and a function that can render them, to a list of model objects that themselves are able to provide `@Composable Content()`.
IMHO the updated API actually feels pretty good, more like the conventional hoisted-state `@Composable Foo(model: FooModel)` idiom.
(Of course I've been working on this all day, so I'm biased.)

We provide a new interface:

```kotlin
interface BackstackFrame<out K : Any> {
  val key: K
  @Composable fun Content()
}
```

And change the signature of the `Backstack()` function:

```kotlin
fun <K : Any> Backstack(
  frames: List<BackstackFrame<K>>,
  modifier: Modifier = Modifier,
  frameController: FrameController<K>
)
```

Note that the param type, `K`, is still the type of the key, not the type of a particular flavor of `BackstackFrame`.
This makes it easy for us to provide convenience functions to map lists of arbitrary model objects to `BackstackFrame` instances, so it's not much more verbose than it used to be to make it go.

Before:

```kotlin
Backstack(backstack) { screen ->
  when(screen) {
    Screen.ContactList -> ShowContactList(navigator)
    is Screen.ContactDetails -> ShowContact(screen.id, navigator)
    is Screen.EditContact -> ShowEditContact(screen.id, navigator)
  }
}
```

After:

```kotlin
Backstack(
  backstack.toBackstackModel { screen ->
    when(screen) {
      Screen.ContactList -> ShowContactList(navigator)
      is Screen.ContactDetails -> ShowContact(screen.id, navigator)
      is Screen.EditContact -> ShowEditContact(screen.id, navigator)
    }
  }
)
```

Note that there are two flavors of `toBackstackModel`. The second one supports models with more interesting keys.

```kotlin
data class Portrait(
  val id: Int,
  val url: String
)

Backstack(
  backstack.toBackstackModel(
    getKey = { it.id }
  ) {
    PrettyPicture(it.url)
  }
)
```

Fixes #63